### PR TITLE
Compatibility with Symfony 3

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -30,7 +30,7 @@
         </service>
 
         <service id="oauth2.client.security.authentication.access_token_listener" class="%oauth2.client.security.authentication.access_token_listener.class%">
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.authentication.manager" />
         </service>
 

--- a/Security/Firewall/OAuth2AccessTokenListener.php
+++ b/Security/Firewall/OAuth2AccessTokenListener.php
@@ -2,8 +2,8 @@
 
 namespace OAuth2\ClientBundle\Security\Firewall;
 
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Http\Firewall\ListenerInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use OAuth2\ClientBundle\Security\Authentication\Token\OAuth2Token;
@@ -11,12 +11,19 @@ use Symfony\Component\HttpFoundation\Response;
 
 class OAuth2AccessTokenListener implements ListenerInterface
 {
-    protected $securityContext;
+    /**
+     * @var TokenStorageInterface
+     */
+    protected $tokenStorage;
+
+    /**
+     * @var AuthenticationManagerInterface
+     */
     protected $authenticationManager;
 
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager)
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager)
     {
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
         $this->authenticationManager = $authenticationManager;
     }
 
@@ -36,7 +43,7 @@ class OAuth2AccessTokenListener implements ListenerInterface
             $token->setAccessToken($access_token);
 
             $authToken = $this->authenticationManager->authenticate($token);
-            $this->securityContext->setToken($authToken);
+            $this->tokenStorage->setToken($authToken);
             return;
         }
 


### PR DESCRIPTION
Use of the security token storage service instead of the deprecated security context service.
