### PR TITLE
Adjust dependencies for Symfony 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+composer.lock

--- a/DependencyInjection/Security/Factory/OAuth2AccessTokenFactory.php
+++ b/DependencyInjection/Security/Factory/OAuth2AccessTokenFactory.php
@@ -5,7 +5,6 @@ namespace OAuth2\ClientBundle\DependencyInjection\Security\Factory;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory;
 
 class OAuth2AccessTokenFactory extends AbstractFactory

--- a/DependencyInjection/Security/Factory/OAuth2AccessTokenFactory.php
+++ b/DependencyInjection/Security/Factory/OAuth2AccessTokenFactory.php
@@ -2,6 +2,7 @@
 
 namespace OAuth2\ClientBundle\DependencyInjection\Security\Factory;
 
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
@@ -23,7 +24,7 @@ class OAuth2AccessTokenFactory extends AbstractFactory
     {
         $providerId = 'security.authentication.provider.oauth2.'.$id;
         $container
-            ->setDefinition($providerId, new DefinitionDecorator('oauth2.client.security.authentication.provider'))
+            ->setDefinition($providerId, new ChildDefinition('oauth2.client.security.authentication.provider'))
             ->replaceArgument(0, new Reference($userProviderId));
         ;
 
@@ -39,7 +40,7 @@ class OAuth2AccessTokenFactory extends AbstractFactory
     {
         $listenerId = 'security.authentication.listener.oauth2.'.$id;
         $container
-            ->setDefinition($listenerId, new DefinitionDecorator('oauth2.client.security.authentication.access_token_listener'));
+            ->setDefinition($listenerId, new ChildDefinition('oauth2.client.security.authentication.access_token_listener'));
 
         return $listenerId;
     }
@@ -48,7 +49,7 @@ class OAuth2AccessTokenFactory extends AbstractFactory
     {
         $entryPointId = 'security.authentication.entry_point.oauth2.'.$id;
         $container
-            ->setDefinition($entryPointId, new DefinitionDecorator('oauth2.client.security.entry_point.access_token_entry_point'));
+            ->setDefinition($entryPointId, new ChildDefinition('oauth2.client.security.entry_point.access_token_entry_point'));
 
         return $entryPointId;
     }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
     "require": {
         "php": ">=7.0.0",
         "guzzlehttp/guzzle": "^6.0",
-        "symfony/symfony": "^2.0 || ^3.0 || ^4.0"
+        "symfony/framework-bundle": "^3.0 || ^4.0",
+        "symfony/security-bundle": "^3.0 || ^4.0",
+        "sensio/framework-extra-bundle": "^5.1"
     },
     "autoload": {
         "psr-0": { "OAuth2\\ClientBundle": "" }


### PR DESCRIPTION
I also removed version `^2.0` as `sensio/framework-extra-bundle` doesn't require it since a while.

Now with Symfony 4 and Flex it's better to dump the exact list of dependencies you need, `symfony/symfony` being a big one that includes every one of them.